### PR TITLE
Switch to MarcPermissiveStreamReader to recover from errors reading Marc records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+marcgrep.dat
+resources/config.clj
+target/

--- a/config/cyan/config.clj
+++ b/config/cyan/config.clj
@@ -1,6 +1,6 @@
-{:output-dir "/var/marcgrep-output"
+{:output-dir "/apps/data/marcgrep-cyan"
 
- :state-file "/var/tmp/marcgrep.dat"
+ :state-file "/apps/data/marcgrep-cyan/marcgrep.dat"
 
  ;; Note: the total number of active threads will be (roughly) these two values multiplied.
  :worker-threads 4

--- a/config/cyan/config.clj
+++ b/config/cyan/config.clj
@@ -1,0 +1,19 @@
+{:output-dir "/var/marcgrep-output"
+
+ :state-file "/var/tmp/marcgrep.dat"
+
+ ;; Note: the total number of active threads will be (roughly) these two values multiplied.
+ :worker-threads 4
+ :max-concurrent-jobs 2
+
+ :marc-destination-list [marcgrep.destinations.marcfile marcgrep.destinations.plaintext]
+
+ :marc-source-list [{:description "Bibliographic and Holdings data"
+                     :driver marcgrep.sources.marc-file
+                     :marc-files ["/apps/data/folio-cache/MARC_BIB.mrc"]}
+
+                    {:description "Authority data"
+                     :driver marcgrep.sources.marc-file
+                     :marc-files ["/apps/data/folio-cache/MARC_AUTHORITY.mrc"]}
+                    ]
+ }

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [org.tigris/marc4j "2.4"]
                  [org.apache.lucene/lucene-core "3.5.0"]]
   :profiles {:prod {:resource-paths ["config/prod"]}
-             :test {:resource-paths ["config/test"]}}
+             :test {:resource-paths ["config/test"]}
+             :cyan {:resource-paths ["config/cyan"]}}
   :plugins [[lein-ring "0.8.8"]]
   :warn-on-reflection false
   :dev-dependencies [[swank-clojure/swank-clojure "1.3.2"]]

--- a/src/marcgrep/sources/marc_file.clj
+++ b/src/marcgrep/sources/marc_file.clj
@@ -5,17 +5,17 @@
             [marcgrep.sources.util :as util]
             [marcgrep.protocols.marc-source :as marc-source])
   (:use clojure.java.io)
-  (:import [org.marc4j MarcStreamReader]
+  (:import [org.marc4j MarcPermissiveStreamReader]
            [java.io FileInputStream]
            [org.marc4j.marc Record VariableField]
            [java.io BufferedReader ByteArrayInputStream]))
 
 
 (deftype MARCFile [^String filename
-                   ^{:unsynchronized-mutable true :tag MarcStreamReader} rdr]
+                   ^{:unsynchronized-mutable true :tag MarcPermissiveStreamReader} rdr]
   marc-source/MarcSource
   (init [this]
-    (set! rdr (MarcStreamReader. (FileInputStream. filename))))
+    (set! rdr (MarcPermissiveStreamReader. (FileInputStream. filename) true true)))
   (next [this]
     (when (.hasNext rdr)
       (.next rdr)))


### PR DESCRIPTION
As part of migrating MARCgrep to use data from FOLIO we want it to be able to read data exported from: 

https://github.com/nla/folio-cache

The existing MARCgrep code uses a MarcStreamReader which will throw an exception if it encounters any issues reading Marc records from file. This was causing it to stop on a record with a very long holdings subfield after reading 720k records out of 5.5 million.

I have switched the code to use:

https://javadoc.io/static/org.marc4j/marc4j/2.9.2/org/marc4j/MarcPermissiveStreamReader.html

which is designed to cope with potentially badly-formed records, and the full data file can now be read. It takes the same amount of time to conduct the search as the current version in Prod (~6 minutes).

Added a config file for the cyan environment (running on spade).